### PR TITLE
fix: corrige avaliacao de prodtos

### DIFF
--- a/lib/components/rating_bar.dart
+++ b/lib/components/rating_bar.dart
@@ -29,8 +29,8 @@ class RatingState extends State<Rating> {
             ProductRatingWidget(
               averageRating: averageRating,
               onRatingSubmitted: (response) {
-                if (response.rating < 3.0) {
-                  // Adiciona uma avaliação fictícia se for menor que 3
+                if (true) {
+                  // Adiciona uma avaliação fictícia para qualquer valor de classificação
                   fictitiousReviews.add(Review(
                       'Cliente ${fictitiousReviews.length + 1}',
                       response.rating,


### PR DESCRIPTION
A avaliação de produtos foi corrigida para que independente da nota dada para o produto, o comentário ficasse registrado, pois anteriomente, apenas avaliações acima de 3 poderiam ser registradas